### PR TITLE
feat: add dynamic portfolio website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# portfolio
+# Raeesha's Portfolio
+
+This is a simple static website that showcases all public projects from [mraeesha](https://github.com/mraeesha) on GitHub (excluding this portfolio repository).
+
+## Features
+
+- Fetches project information dynamically from GitHub's REST API.
+- Displays repository name and description in a clean card layout.
+- Responsive design that works on mobile and desktop.
+
+## Development
+
+No build step is required. Open `index.html` in a browser or serve the folder with any static file server.
+
+```bash
+npx serve .
+```
+
+## Testing
+
+This project does not include automated tests. Run `npm test` to see the default behaviour.
+
+```bash
+npm test
+```

--- a/index.html
+++ b/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Raeesha's Portfolio</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header>
+    <h1>Raeesha's Projects</h1>
+    <p>A collection of my work on GitHub.</p>
+  </header>
+  <main id="projects" class="projects"></main>
+  <footer>
+    <p>Powered by GitHub API</p>
+  </footer>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,24 @@
+async function loadProjects() {
+  try {
+    const response = await fetch('https://api.github.com/users/mraeesha/repos?per_page=100');
+    const repos = await response.json();
+    const container = document.getElementById('projects');
+
+    repos
+      .filter(repo => repo.name !== 'portfolio')
+      .forEach(repo => {
+        const card = document.createElement('div');
+        card.className = 'project-card';
+        card.innerHTML = `
+          <h3>${repo.name}</h3>
+          <p>${repo.description || 'No description provided.'}</p>
+          <a href="${repo.html_url}" target="_blank" rel="noopener">View on GitHub</a>
+        `;
+        container.appendChild(card);
+      });
+  } catch (err) {
+    console.error('Failed to load projects', err);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', loadProjects);

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,54 @@
+:root {
+  --bg-color: #f5f5f5;
+  --text-color: #333;
+  --accent-color: #007acc;
+  --card-bg: #fff;
+}
+
+body {
+  margin: 0;
+  font-family: Arial, Helvetica, sans-serif;
+  background: var(--bg-color);
+  color: var(--text-color);
+  line-height: 1.6;
+}
+
+header {
+  text-align: center;
+  padding: 2rem 1rem;
+  background: var(--card-bg);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.projects {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1rem;
+  padding: 2rem;
+}
+
+.project-card {
+  background: var(--card-bg);
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+}
+
+.project-card h3 {
+  margin-top: 0;
+}
+
+.project-card a {
+  margin-top: auto;
+  color: var(--accent-color);
+  text-decoration: none;
+}
+
+footer {
+  text-align: center;
+  padding: 1rem;
+  font-size: 0.9rem;
+  color: #777;
+}


### PR DESCRIPTION
## Summary
- create static portfolio site that fetches GitHub projects dynamically
- add responsive card-based layout and basic styles
- document usage and development steps in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689294f26f2083279654dfbc8f49dc43