### PR TITLE
feat: refresh portfolio styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <header>
-    <h1>Raeesha's Projects</h1>
+    <h1>Project Portfolio</h1>
     <p>A collection of my work on GitHub.</p>
   </header>
   <main id="projects" class="projects"></main>

--- a/script.js
+++ b/script.js
@@ -11,8 +11,9 @@ async function loadProjects() {
         card.className = 'project-card';
         card.innerHTML = `
           <h3>${repo.name}</h3>
+          ${repo.language ? `<span class="tag">${repo.language}</span>` : ''}
           <p>${repo.description || 'No description provided.'}</p>
-          <a href="${repo.html_url}" target="_blank" rel="noopener">View on GitHub</a>
+          <a href="${repo.html_url}" target="_blank" rel="noopener" class="btn">View on GitHub</a>
         `;
         container.appendChild(card);
       });

--- a/styles.css
+++ b/styles.css
@@ -1,8 +1,11 @@
 :root {
-  --bg-color: #f5f5f5;
-  --text-color: #333;
-  --accent-color: #007acc;
-  --card-bg: #fff;
+  --primary-color: #0B1F3A;
+  --accent-color: #2979FF;
+  --accent-hover: #1c54b2;
+  --bg-color: #F9F9F9;
+  --text-color: #333333;
+  --secondary-accent: #FF6B6B;
+  --card-bg: #FFFFFF;
 }
 
 body {
@@ -15,8 +18,9 @@ body {
 
 header {
   text-align: center;
-  padding: 2rem 1rem;
-  background: var(--card-bg);
+  padding: 1rem;
+  background: var(--primary-color);
+  color: var(--bg-color);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
@@ -38,17 +42,41 @@ header {
 
 .project-card h3 {
   margin-top: 0;
+  color: var(--text-color);
+}
+
+.tag {
+  background: var(--secondary-accent);
+  color: #fff;
+  align-self: flex-start;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  margin-bottom: 0.5rem;
 }
 
 .project-card a {
   margin-top: auto;
-  color: var(--accent-color);
   text-decoration: none;
+}
+
+.btn {
+  background: var(--accent-color);
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  display: inline-block;
+  transition: background 0.3s ease;
+}
+
+.btn:hover {
+  background: var(--accent-hover);
 }
 
 footer {
   text-align: center;
   padding: 1rem;
   font-size: 0.9rem;
-  color: #777;
+  background: var(--primary-color);
+  color: #ccc;
 }


### PR DESCRIPTION
## Summary
- apply new brand color palette to layout
- show repo language tags and style project links as buttons
- rename projects heading to "Project Portfolio"

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892a2a6194c83278d9e57a390acb67f