### PR TITLE
Remove placeholder project descriptions

### DIFF
--- a/script.js
+++ b/script.js
@@ -53,10 +53,12 @@ async function loadProjects() {
               : '';
         const card = document.createElement('div');
         card.className = 'project-card';
+        const description = info.description || repo.description;
+        const descriptionHtml = description ? `<p>${description}</p>` : '';
         card.innerHTML = `
           <h3>${name}</h3>
           ${tagHtml}
-          <p>${info.description || repo.description || 'No description provided.'}</p>
+          ${descriptionHtml}
           <a href="${repo.html_url}" target="_blank" rel="noopener" class="btn">View on GitHub</a>
         `;
         container.appendChild(card);


### PR DESCRIPTION
## Summary
- Only render project descriptions when available instead of showing "No description provided"

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892a9eeefac8327b2bc2e195714e1bb